### PR TITLE
Small fixes and doc skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Copyright (c) 2023, PickNik Robotics
 
 ## Folder Structure
 
+The `doc` folder contains detailed, per-section instructions to follow along with the training materials.
+
 The `src` folder contains completed packages to directly build this workspace and explore the solutions.
 
 The `starter_files` folder contains initial files to copy over for the hands-on training.

--- a/doc/01_installing_moveit_studio.md
+++ b/doc/01_installing_moveit_studio.md
@@ -1,0 +1,3 @@
+# Installing MoveIt Studio
+
+TODO: Fill out steps

--- a/doc/02_creating_objectives.md
+++ b/doc/02_creating_objectives.md
@@ -1,0 +1,3 @@
+# Creating Objectives from Built-In Behaviors
+
+TODO: Fill out steps

--- a/doc/03_configuration_packages.md
+++ b/doc/03_configuration_packages.md
@@ -1,0 +1,3 @@
+# Working with MoveIt Studio Configuration Packages
+
+TODO: Fill out steps

--- a/doc/04_custom_behaviors.md
+++ b/doc/04_custom_behaviors.md
@@ -1,0 +1,3 @@
+# Creating Custom Behaviors
+
+TODO: Fill out steps

--- a/doc/05_calling_external_services.md
+++ b/doc/05_calling_external_services.md
@@ -1,0 +1,3 @@
+# Creating Behaviors that Call External ROS Services
+
+TODO: Fill out steps

--- a/doc/06_moveit_task_constructor.md
+++ b/doc/06_moveit_task_constructor.md
@@ -1,0 +1,3 @@
+# Creating Motion Planning Behaviors with MoveIt Task Constructor
+
+TODO: Fill out steps

--- a/doc/07_running_objectives_from_python.md
+++ b/doc/07_running_objectives_from_python.md
@@ -1,0 +1,3 @@
+# Running Objectives using Python
+
+TODO: Fill out steps

--- a/src/moveit_studio_training_behaviors/src/transform_pose.cpp
+++ b/src/moveit_studio_training_behaviors/src/transform_pose.cpp
@@ -74,9 +74,9 @@ namespace moveit_studio_training_behaviors
     output_pose.pose = tf2::toMsg(output_pose_eigen);
   
     // Print the transformed pose for debugging purposes.
-    std::cout << "Transformed pose" << std::endl;
-    std::cout << "  Frame ID: " << output_pose.header.frame_id;
-    std::cout << "  Translation: " << output_pose_eigen.translation().x() << " " << output_pose_eigen.translation().y() << " " << output_pose_eigen.translation().z() << std::endl;
+    std::cout << "Transformed pose" << "\n";
+    std::cout << "  Frame ID: " << output_pose.header.frame_id << "\n";
+    std::cout << "  Translation: " << output_pose_eigen.translation().x() << " " << output_pose_eigen.translation().y() << " " << output_pose_eigen.translation().z() << "\n";
     Eigen::Quaterniond q_out(output_pose_eigen.linear());
     std::cout << "  Orientation: " << q_out.x() << " " << q_out.y() << " " << q_out.z() << " " << q_out.w() << std::endl;
 

--- a/starter_files/start_msa.sh
+++ b/starter_files/start_msa.sh
@@ -1,3 +1,0 @@
-#!/bin/bash -eux
-
-docker exec -it moveit_studio-agent-1 bash -c "source /opt/moveit_studio/user_ws/install/setup.bash && ros2 run moveit_setup_assistant moveit_setup_assistant --urdf /opt/moveit_studio/user_ws/starter_files/description/robot.urdf"


### PR DESCRIPTION
This PR

* Implements a few small fixes from our dry run (duplicate MSA file and missing newline)
* Adds a bare skeleton for README files for attendees to follow along. We can fill these in along with the slides.